### PR TITLE
Use .huskyrc config file

### DIFF
--- a/.huskyrc
+++ b/.huskyrc
@@ -1,0 +1,5 @@
+{
+  "hooks": {
+    "pre-commit": "yarn fix && yarn test"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -36,10 +36,5 @@
     "vue": "^2.5.21",
     "vue-class-component": "^6.3.2",
     "vue-property-decorator": "^7.2.0"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "yarn fix && yarn test"
-    }
   }
 }


### PR DESCRIPTION
Starting from v1.0.0, husky supports a separate configuration file, which is cleaner than putting the configuration in `package.json`.

Reference: [husky changelog](https://github.com/typicode/husky/blob/master/CHANGELOG.md#100)