### PR TITLE
Add commitlint configuration to enable commitlint

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,1 @@
+module.exports = { extends: ["@commitlint/config-conventional"] };

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "es2015": "dist/vue-simple-icons.esm.js",
   "devDependencies": {
     "@commitlint/cli": "^7.2.1",
+    "@commitlint/config-conventional": "^7.1.2",
     "@types/jest": "^23.3.10",
     "@vue/test-utils": "^1.0.0-beta.27",
     "commitizen": "^3.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -36,6 +36,11 @@
     resolve-from "^4.0.0"
     resolve-global "^0.1.0"
 
+"@commitlint/config-conventional@^7.1.2":
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/@commitlint/config-conventional/-/config-conventional-7.1.2.tgz#5b5e45924c9abd8f9a8d83eb1f66e24e5f66916f"
+  integrity sha512-DmA4ixkpv03qA1TVs1Bl25QsVym2bPL6pKapesALWIVggG3OpwqGZ55vN75Tx8xZoG7LFKrVyrt7kwhA7X8njQ==
+
 "@commitlint/ensure@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@commitlint/ensure/-/ensure-7.2.0.tgz#03cfab7135f57f62b73698f441a516886a84a1f6"


### PR DESCRIPTION
# Description
As I mentioned in [this comment](https://github.com/sh7dm/vue-simple-icons/pull/7#issuecomment-447848715) we forgot to add a commtlint configuration, which resulted in commitlint not doing anything.

# Why is this change required?
To enable commitlint and enforce proper commit messages 😇 

- [x] I've read the contributing guidelines and the Code of Conduct
