### PR TITLE
Config/editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,6 @@
 [*]
+end_of_line = crlf
 indent_size = 2
 indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,4 @@
 [*]
-end_of_line = crlf
 indent_size = 2
 indent_style = space
 insert_final_newline = true


### PR DESCRIPTION
# Description
Updated the `.editorconfig` file (for more details see the [EditorConfig website](https://editorconfig.org/)).

- Automatically insert final new line (since some editors do this automatically, but no editor automatically removes it)
- Trim trailing whitespace (because file size)

# Why is this change required?
<!-- e.g. fix #1234 -->
- [x] I've read the contributing guidelines and the Code of Conduct
