### PR TITLE
Improve renderError function

### DIFF
--- a/src/VueSimpleIcon.ts
+++ b/src/VueSimpleIcon.ts
@@ -3,6 +3,7 @@ import Vue, { VNode } from "vue";
 import Component from "vue-class-component";
 import { Prop } from "vue-property-decorator";
 import * as SimpleIcons from "simple-icons";
+import { renderError } from "./util";
 
 @Component<VueSimpleIcon>({
   render(createElement: Function): VNode {
@@ -83,23 +84,3 @@ export default class VueSimpleIcon extends Vue {
     return 24;
   }
 }
-
-const renderError = (
-  title: string,
-  iconSize: number | string,
-  h: Function
-): VNode =>
-  h(
-    "svg",
-    {
-      attrs: {
-        width: iconSize,
-        height: iconSize,
-        viewBox: "0 0 24 24",
-        xmlns: "http://www.w3.org/2000/svg"
-      },
-      domProps: {
-        innerHTML: `<title>${title}</title><circle cx=\"12\" cy=\"12\" r=\"12\" fill=\"red\"></circle><line x1=\"12\" y1=\"20\" x2=\"12\" y2=\"20\" stroke=\"#fff\" fill=\"none\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-miterlimit=\"10\"></line><line x1=\"12\" y1=\"5\" x2=\"12\" y2=\"15\" stroke=\"#fff\" fill=\"none\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-miterlimit=\"10\"></line>`
-      }
-    }
-  );

--- a/src/VueSimpleIcon.ts
+++ b/src/VueSimpleIcon.ts
@@ -97,43 +97,9 @@ const renderError = (
         height: iconSize,
         viewBox: "0 0 24 24",
         xmlns: "http://www.w3.org/2000/svg"
+      },
+      domProps: {
+        innerHTML: `<title>${title}</title><circle cx=\"12\" cy=\"12\" r=\"12\" fill=\"red\"></circle><line x1=\"12\" y1=\"20\" x2=\"12\" y2=\"20\" stroke=\"#fff\" fill=\"none\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-miterlimit=\"10\"></line><line x1=\"12\" y1=\"5\" x2=\"12\" y2=\"15\" stroke=\"#fff\" fill=\"none\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-miterlimit=\"10\"></line>`
       }
-    },
-    [
-      h("title", {}, [title]),
-      h("circle", {
-        attrs: {
-          cx: 12,
-          cy: 12,
-          r: 12,
-          fill: "red"
-        }
-      }),
-      h("line", {
-        attrs: {
-          x1: 12,
-          y1: 20,
-          x2: 12,
-          y2: 20,
-          stroke: "#fff",
-          fill: "none",
-          "stroke-width": 2,
-          "stroke-linecap": "round",
-          "stroke-miterlimit": 10
-        }
-      }),
-      h("line", {
-        attrs: {
-          x1: 12,
-          y1: 5,
-          x2: 12,
-          y2: 15,
-          stroke: "#fff",
-          fill: "none",
-          "stroke-width": 2,
-          "stroke-linecap": "round",
-          "stroke-miterlimit": 10
-        }
-      })
-    ]
+    }
   );

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,19 @@
+/// <reference path="./simple-icons.d.ts" />
+import { VNode } from "vue";
+
+export const renderError = (
+  title: string,
+  iconSize: number | string,
+  h: Function
+): VNode =>
+  h("svg", {
+    attrs: {
+      width: iconSize,
+      height: iconSize,
+      viewBox: "0 0 24 24",
+      xmlns: "http://www.w3.org/2000/svg"
+    },
+    domProps: {
+      innerHTML: `<title>${title}</title><circle cx=\"12\" cy=\"12\" r=\"12\" fill=\"red\"></circle><line x1=\"12\" y1=\"20\" x2=\"12\" y2=\"20\" stroke=\"#fff\" fill=\"none\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-miterlimit=\"10\"></line><line x1=\"12\" y1=\"5\" x2=\"12\" y2=\"15\" stroke=\"#fff\" fill=\"none\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-miterlimit=\"10\"></line>`
+    }
+  });


### PR DESCRIPTION
- [x] I've read the contributing guidelines and the Code of Conduct

# Description
Update the `renderError` method to not construct each part of the SVG every time it is called

# Why is this change required?
Improve performance 🐎